### PR TITLE
Fix "namespace not specified" compliance issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains sample Kubernetes manifest files that can be deployed u
 ## Prerequisites
 
 One or more AKS clusters with the GitOps AKS add-on enabled. \
-The `connectedk8s` Azure CLI extension installed.
+The `k8s-configuration` Azure CLI extension installed.
 
 ## Running the sample
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,16 @@ The `connectedk8s` Azure CLI extension installed.
 
 ## Running the sample
 
-Create a GitOps configuration referencing this sample repo by using the Azure CLI extension `k8sconfiguration`. Complete documentation on the available options can be found [here](https://pixelrobots.co.uk).
+Create a GitOps configuration referencing this sample repo by using the Azure CLI extension `k8s-configuration`. Complete documentation on the available options can be found [here](https://pixelrobots.co.uk).
 
 After a configuration is created, AKS will instantiate the resources described in this repository. This includes creating namespaces, deploying an example workload, and a config map.
 
 ```console
-az k8sconfiguration create \
-    --name cluster-config \
+az k8s-configuration flux create  \
     --cluster-name ${CLUSTER_NAME} --resource-group ${RESOURCE_GROUP} \
-    --operator-instance-name cluster-config --operator-namespace cluster-config \
-    --repository-url https://github.com/PixelRobots/aks-gitops-demo \
-    --scope cluster --cluster-type managedClusters \
-    --operator-params='--git-branch=main'
+    --cluster-type managedClusters \
+    --name cluster-config --scope cluster --namespace cluster-config \
+    --kind git --url https://github.com/PixelRobots/aks-gitops-demo \
+    --branch main --kustomization name=my-kustomization
 ```
 

--- a/cluster-apps/aks-gitops-demo.yaml
+++ b/cluster-apps/aks-gitops-demo.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: aks-gitops-demo
+  namespace: itops
 spec:
   replicas: 1
   selector:
@@ -43,6 +44,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: aks-gitops-demo
+  namespace: itops
   labels:
     name: aks-gitops-demo
 spec:


### PR DESCRIPTION
By default, the error will pop due to _no namespace can be found_. 
```
[
    {
        "lastTransitionTime": "2024-02-07T06:29:27+00:00",
        "message": "Detecting drift for revision main@sha1:309f8c844bcae5b0d4bd01de8caf1bbb291a2914 with a timeout of 10m0s",
        "reason": "ProgressingWithRetry",
        "status": "True",
        "type": "Reconciling"
    },
    {
        "lastTransitionTime": "2024-02-07T06:29:27+00:00",
        "message": "Deployment/aks-gitops-demo namespace not specified: the server could not find the requested resource\n",
        "reason": "ReconciliationFailed",
        "status": "False",
        "type": "Ready"
    }
]
```